### PR TITLE
Make favicon paths absolute

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,9 +2,9 @@
     <!-- Mobile Specific Meta -->
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <!-- Favicon-->
-    <link rel="icon" type="image/png" sizes="32x32" href="img/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="96x96" href="img/favicon-96x96.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="img/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="/img/favicon-96x96.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/img/favicon-16x16.png">
     <!-- Author Meta -->
     <meta name="author" content="colorlib">
     <!-- Meta Description -->


### PR DESCRIPTION
Change the favicon paths to absolute paths so they can be found on pages other than `index.html`. 

Currently in the `head.html` document the paths to the favicons are relative, meaning that for pages other than `index.html` they cannot be found.